### PR TITLE
Fixes generateStaticParams

### DIFF
--- a/src/app/[lng]/layout.tsx
+++ b/src/app/[lng]/layout.tsx
@@ -6,6 +6,7 @@ import { PropsWithChildren } from "react";
 import { CommonPageParams } from "../types";
 import { Metadata, ResolvingMetadata } from "next/types";
 import { Lang } from "../../components/types";
+import { supportedLngs } from "../i18n/settings";
 
 export default function MainLayout({ children, params }: PropsWithChildren & CommonPageParams) {
   return (
@@ -68,4 +69,8 @@ export async function generateMetadata({ params }: CommonPageParams, parent: Res
       description: descriptionLang[params.lng],
     },
   };
+}
+
+export function generateStaticParams() {
+  return supportedLngs.map((lng) => ({ lng }));
 }

--- a/src/app/[lng]/page.tsx
+++ b/src/app/[lng]/page.tsx
@@ -7,7 +7,6 @@ import { AchievementsBlock } from "./achievements-block";
 import { NewsBlock } from "./news-block";
 import { EventsBlock } from "./events-block";
 import { CommonPageParams } from "../types";
-import { supportedLngs } from "../i18n/settings";
 import { useTranslation } from "../i18n";
 
 interface MainPageProps {
@@ -49,10 +48,6 @@ export default async function IndexPage({ params: { lng } }: CommonPageParams) {
       </Section>
     </>
   );
-}
-
-export async function generateStaticParams() {
-  return supportedLngs.map((lng) => ({ lng }));
 }
 
 function hasTwoSecondaryNews(secondaryNews: ArticleMeta[]): secondaryNews is [ArticleMeta, ArticleMeta] {


### PR DESCRIPTION
Moves generateStaticParams from root page to root layout according to https://github.com/vercel/next.js/issues/42840#issuecomment-1352105907